### PR TITLE
refactor: 검색 페이징 api 변경 적용 

### DIFF
--- a/src/hooks/queries/search/useInfiniteProductSearchAutocompleteQuery.ts
+++ b/src/hooks/queries/search/useInfiniteProductSearchAutocompleteQuery.ts
@@ -3,8 +3,8 @@ import { useSuspendedInfiniteQuery } from '..';
 import { searchApi } from '@/apis';
 import type { ProductSearchAutocompleteResponse } from '@/types/response';
 
-const fetchProductSearchAutocomplete = async (query: string, page: number) => {
-  const response = await searchApi.get({ params: '/products', queries: `?query=${query}&page=${page}` });
+const fetchProductSearchAutocomplete = async (query: string, pageParam: number) => {
+  const response = await searchApi.get({ params: '/products', queries: `?query=${query}&lastProductId=${pageParam}` });
   const data: ProductSearchAutocompleteResponse = await response.json();
 
   return data;
@@ -16,9 +16,10 @@ const useInfiniteProductSearchAutocompleteQuery = (query: string) => {
     ({ pageParam = 0 }) => fetchProductSearchAutocomplete(query, pageParam),
     {
       getNextPageParam: (prevResponse: ProductSearchAutocompleteResponse) => {
-        const isLast = prevResponse.page.lastPage;
-        const nextPage = prevResponse.page.requestPage + 1;
-        return isLast ? undefined : nextPage;
+        const lastCursor = prevResponse.products.length
+          ? prevResponse.products[prevResponse.products.length - 1].id
+          : 0;
+        return prevResponse.hasNext ? lastCursor : undefined;
       },
     }
   );

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -45,7 +45,7 @@ export interface ProductSearchAutocompleteResponse {
 }
 
 export interface ProductSearchResultResponse {
-  page: Page;
+  hasNext: boolean;
   products: ProductSearchResult[];
 }
 

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,7 +1,7 @@
 import type { Product } from './product';
 import type { ProductRanking, RecipeRanking, ReviewRanking } from './ranking';
 import type { Comment, MemberRecipe, Recipe } from './recipe';
-import type { Review, ReviewDetail } from './review';
+import type { Review } from './review';
 import type { ProductSearchResult, ProductSearchAutocomplete } from './search';
 
 export interface Page {
@@ -40,7 +40,7 @@ export interface RecipeRankingResponse {
 }
 
 export interface ProductSearchAutocompleteResponse {
-  page: Page;
+  hasNext: boolean;
   products: ProductSearchAutocomplete[];
 }
 

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -30,6 +30,11 @@ export interface ProductRankingResponse {
   products: ProductRanking[];
 }
 
+export interface RecipeSearchResponse {
+  hasNext: boolean;
+  recipes: Recipe[];
+}
+
 export interface RecipeResponse {
   page: Page;
   recipes: Recipe[];

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -12,14 +12,44 @@ export interface Page {
   requestPage: number;
   requestSize: number;
 }
-
-export interface CategoryProductResponse {
-  hasNext: boolean;
-  products: Product[];
+export interface ErrorResponse {
+  code: number;
+  message: string;
 }
-export interface ProductReviewResponse {
+
+type DataKeys = 'products' | 'reviews' | 'recipes' | 'comments';
+
+type CommonInfiniteQueryResponse<T, K extends DataKeys> = {
   hasNext: boolean;
-  reviews: Review[];
+} & {
+  [P in K]: T[];
+};
+
+export type CategoryProductResponse = CommonInfiniteQueryResponse<Product, 'products'>;
+
+export type ProductReviewResponse = CommonInfiniteQueryResponse<Review, 'reviews'>;
+
+export type RecipeSearchResponse = CommonInfiniteQueryResponse<Recipe, 'recipes'>;
+
+export type ProductSearchAutocompleteResponse = CommonInfiniteQueryResponse<ProductSearchAutocomplete, 'products'>;
+
+export type ProductSearchResultResponse = CommonInfiniteQueryResponse<ProductSearchResult, 'products'>;
+
+export type CommentResponse = CommonInfiniteQueryResponse<Comment, 'comments'> & { totalElements: number | null };
+
+export interface RecipeResponse {
+  page: Page;
+  recipes: Recipe[];
+}
+
+export interface MemberReviewResponse {
+  page: Page;
+  reviews: ReviewRanking[];
+}
+
+export interface MemberRecipeResponse {
+  page: Page;
+  recipes: MemberRecipe[];
 }
 
 export interface ReviewRankingResponse {
@@ -30,47 +60,6 @@ export interface ProductRankingResponse {
   products: ProductRanking[];
 }
 
-export interface RecipeSearchResponse {
-  hasNext: boolean;
-  recipes: Recipe[];
-}
-
-export interface RecipeResponse {
-  page: Page;
-  recipes: Recipe[];
-}
-
 export interface RecipeRankingResponse {
   recipes: RecipeRanking[];
-}
-
-export interface ProductSearchAutocompleteResponse {
-  hasNext: boolean;
-  products: ProductSearchAutocomplete[];
-}
-
-export interface ProductSearchResultResponse {
-  hasNext: boolean;
-  products: ProductSearchResult[];
-}
-
-export interface MemberReviewResponse {
-  page: Page;
-  reviews: ReviewRanking[];
-}
-
-export interface ErrorResponse {
-  code: number;
-  message: string;
-}
-
-export interface MemberRecipeResponse {
-  page: Page;
-  recipes: MemberRecipe[];
-}
-
-export interface CommentResponse {
-  hasNext: boolean;
-  totalElements: number | null;
-  comments: Comment[];
 }


### PR DESCRIPTION
## Issue

- close #7

## ✨ 구현한 기능

- 검색 결과 자동완성, 상품 검색 결과, 꿀조합 검색 결과 api 변경된 부분 적용

## 📢 논의하고 싶은 내용

지금 무한스크롤 관련된 타입들 보면

```tsx
interface XX {
  hasNext: boolean;
  XX: Type[]
}
```
이런형식인데 이거 깔쌈하게 리팩토링 할 방법 없을까여

## 🎸 기타

- 백엔드 머지 되고 머지 되어야 함

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 : 10분
