### PR TITLE
refactor: 내비게이션바 개편

### DIFF
--- a/src/components/Common/NavigationBar/NavigationBar.tsx
+++ b/src/components/Common/NavigationBar/NavigationBar.tsx
@@ -1,63 +1,35 @@
-import { Link, Text, theme } from '@fun-eat/design-system';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
 
+import { menuName, navigationBarContainer, navigationLink, navigationList } from './navigationBar.css';
 import SvgIcon from '../Svg/SvgIcon';
 
 import { NAVIGATION_MENU } from '@/constants';
 
 const NavigationBar = () => {
-  const location = useLocation();
-
   return (
-    <NavigationBarContainer>
-      <NavigationBarList>
-        {NAVIGATION_MENU.map(({ variant, name, path }) => {
-          const currentPath = location.pathname.split('/')[1];
-          const isSelected = currentPath === path.split('/')[1];
-
-          return (
-            <NavigationItem key={variant}>
-              <NavigationLink as={RouterLink} to={path}>
-                <SvgIcon variant={variant} fill={isSelected ? theme.colors.gray5 : theme.colors.gray3} />
-                <Text size="xs" color={isSelected ? theme.colors.gray5 : theme.colors.gray3}>
-                  {name}
-                </Text>
-              </NavigationLink>
-            </NavigationItem>
-          );
-        })}
-      </NavigationBarList>
-    </NavigationBarContainer>
+    <nav className={navigationBarContainer}>
+      <ul className={navigationList}>
+        {NAVIGATION_MENU.map(({ variant, name, path }) => (
+          <li key={variant}>
+            <NavLink to={path} className={navigationLink}>
+              {({ isActive }) => (
+                <>
+                  <SvgIcon
+                    variant={variant}
+                    width={20}
+                    height={20}
+                    fill="none"
+                    stroke={isActive ? '#ffb017' : '#a0a0a0'}
+                  />
+                  <span className={isActive ? menuName['active'] : menuName['default']}>{name}</span>
+                </>
+              )}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 };
 
 export default NavigationBar;
-
-const NavigationBarContainer = styled.nav`
-  width: 100%;
-  height: 60px;
-`;
-
-const NavigationBarList = styled.ul`
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  padding-top: 12px;
-  border: 1px solid ${({ theme }) => theme.borderColors.disabled};
-  border-bottom: none;
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-`;
-
-const NavigationItem = styled.li`
-  height: 50px;
-`;
-
-const NavigationLink = styled(Link)`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  justify-content: flex-end;
-  align-items: center;
-`;

--- a/src/components/Common/NavigationBar/navigationBar.css.ts
+++ b/src/components/Common/NavigationBar/navigationBar.css.ts
@@ -1,0 +1,34 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+export const navigationBarContainer = style({
+  width: '100%',
+  height: 70,
+  paddingBottom: 6,
+});
+
+export const navigationList = style({
+  display: 'flex',
+  justifyContent: 'space-around',
+  alignItems: 'center',
+  height: '100%',
+  borderTop: '1px solid #f9f9f9',
+});
+
+export const navigationLink = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const menuNameBase = style({
+  fontSize: 11,
+  textAlign: 'center',
+  lineHeight: 1.4,
+});
+
+export const menuName = styleVariants({
+  active: [menuNameBase, { color: '#ffb017' }],
+  default: [menuNameBase, { color: '#a0a0a0' }],
+});

--- a/src/components/Common/NavigationBar/navigationBar.css.ts
+++ b/src/components/Common/NavigationBar/navigationBar.css.ts
@@ -11,7 +11,7 @@ export const navigationList = style({
   justifyContent: 'space-around',
   alignItems: 'center',
   height: '100%',
-  borderTop: '1px solid #f9f9f9',
+  border: '1px solid #f9f9f9',
 });
 
 export const navigationLink = style({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,22 +4,22 @@ import type { NavigationMenu } from '@/types/common';
 
 export const NAVIGATION_MENU: NavigationMenu[] = [
   {
-    variant: 'list',
-    name: '목록',
+    variant: 'category2',
+    name: '카테고리',
     path: `${PATH.PRODUCT_LIST}/food`,
   },
   {
-    variant: 'home',
+    variant: 'home2',
     name: '홈',
     path: PATH.HOME,
   },
   {
-    variant: 'recipe',
-    name: '꿀조합',
+    variant: 'recipe2',
+    name: '조합실',
     path: PATH.RECIPE,
   },
   {
-    variant: 'member',
+    variant: 'member2',
     name: '마이',
     path: PATH.MEMBER,
   },

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -32,7 +32,7 @@ export interface Tag {
 
 export interface NavigationMenu {
   variant: SvgIconVariant;
-  name: '검색' | '목록' | '홈' | '꿀조합' | '마이';
+  name: '카테고리' | '홈' | '조합실' | '마이';
   path: (typeof PATH)[keyof typeof PATH] | '/products/food' | '/products/store';
 }
 


### PR DESCRIPTION
## Issue

- close #19 

## ✨ 구현한 기능

- 기존 내비게이션 이름 및 아이콘 변경
- styled -> vanilla-extract
<img width="1042" alt="스크린샷 2024-03-09 00 29 29" src="https://github.com/fun-eat/funeat-client/assets/78616893/0015670b-4046-4823-a305-26219b570a26">


## 📢 논의하고 싶은 내용

- 논의하고 싶은 내용을 작성합니다.

## 🎸 기타

- 기존 path를 이용해 스타일링하던 것을 router-dom의 NavLink를 사용해 스타일 적용했습니다.

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 1시간
