### PR TITLE
feat: 상품 랭킹 구현

### DIFF
--- a/src/components/Rank/ProductRankingItem/ProductRankingItem.stories.tsx
+++ b/src/components/Rank/ProductRankingItem/ProductRankingItem.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ProductRankingItem from './ProductRankingItem';
+
+const meta: Meta<typeof ProductRankingItem> = {
+  title: 'product/ProductRankingItem',
+  component: ProductRankingItem,
+  args: {
+    image: 'https://arqachylpmku8348141.cdn.ntruss.com/app/product/mst_product/8801056232979_L.jpg',
+    name: '펩시제로콜라',
+    rank: 1,
+    price: 2200,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Ranking: Story = {
+  args: {
+    rank: 1,
+  },
+};

--- a/src/components/Rank/ProductRankingItem/ProductRankingItem.tsx
+++ b/src/components/Rank/ProductRankingItem/ProductRankingItem.tsx
@@ -1,10 +1,10 @@
 import {
-  productRankingImageWrapper,
-  productRankingImage,
-  productRankingTitle,
-  productRankingPrice,
-  productRankingRank,
-  productRankingItemContainer,
+  container,
+  imageWrapper,
+  productImage,
+  productRank,
+  productTitle,
+  productPrice,
 } from './productRankingItem.css';
 
 interface ProductRankingItemProps {
@@ -16,15 +16,15 @@ interface ProductRankingItemProps {
 
 const ProductRankingItem = ({ name, image, rank, price }: ProductRankingItemProps) => {
   return (
-    <div className={productRankingItemContainer}>
-      <div className={productRankingImageWrapper}>
-        {image && <img className={productRankingImage} src={image} alt={name} />}
-        <p className={productRankingRank}>{rank}</p>
+    <div className={container}>
+      <div className={imageWrapper}>
+        {image && <img className={productImage} src={image} alt={name} />}
+        <p className={productRank}>{rank}</p>
       </div>
       <div style={{ height: '5px' }} />
-      <p className={productRankingTitle}>{name}</p>
+      <p className={productTitle}>{name}</p>
       <div style={{ height: '2px' }} />
-      <p className={productRankingPrice}>{price.toLocaleString('ko-KR')}원</p>
+      <p className={productPrice}>{price.toLocaleString('ko-KR')}원</p>
     </div>
   );
 };

--- a/src/components/Rank/ProductRankingItem/ProductRankingItem.tsx
+++ b/src/components/Rank/ProductRankingItem/ProductRankingItem.tsx
@@ -1,0 +1,32 @@
+import {
+  productRankingImageWrapper,
+  productRankingImage,
+  productRankingTitle,
+  productRankingPrice,
+  productRankingRank,
+  productRankingItemContainer,
+} from './productRankingItem.css';
+
+interface ProductRankingItemProps {
+  name: string;
+  image: string | null;
+  rank: number;
+  price: number;
+}
+
+const ProductRankingItem = ({ name, image, rank, price }: ProductRankingItemProps) => {
+  return (
+    <div className={productRankingItemContainer}>
+      <div className={productRankingImageWrapper}>
+        {image && <img className={productRankingImage} src={image} alt={name} />}
+        <p className={productRankingRank}>{rank}</p>
+      </div>
+      <div style={{ height: '5px' }} />
+      <p className={productRankingTitle}>{name}</p>
+      <div style={{ height: '2px' }} />
+      <p className={productRankingPrice}>{price.toLocaleString('ko-KR')}원</p>
+    </div>
+  );
+};
+
+export default ProductRankingItem;

--- a/src/components/Rank/ProductRankingItem/productRankingItem.css.ts
+++ b/src/components/Rank/ProductRankingItem/productRankingItem.css.ts
@@ -1,10 +1,10 @@
 import { style } from '@vanilla-extract/css';
 
-export const productRankingItemContainer = style({
+export const container = style({
   width: 144,
 });
 
-export const productRankingImageWrapper = style({
+export const imageWrapper = style({
   position: 'relative',
   width: '100%',
   height: 144,
@@ -12,13 +12,13 @@ export const productRankingImageWrapper = style({
   borderRadius: 6,
 });
 
-export const productRankingImage = style({
+export const productImage = style({
   width: '100%',
   height: '100%',
   borderRadius: 6,
 });
 
-export const productRankingRank = style({
+export const productRank = style({
   position: 'absolute',
   top: 10,
   left: 10,
@@ -29,7 +29,7 @@ export const productRankingRank = style({
   fontWeight: '500',
 });
 
-export const productRankingTitle = style({
+export const productTitle = style({
   color: '#232527',
   fontSize: 13,
   fontWeight: 600,
@@ -38,7 +38,7 @@ export const productRankingTitle = style({
   overflow: 'hidden',
 });
 
-export const productRankingPrice = style({
+export const productPrice = style({
   color: '#808080',
   fontSize: 12,
   fontWeight: 600,

--- a/src/components/Rank/ProductRankingItem/productRankingItem.css.ts
+++ b/src/components/Rank/ProductRankingItem/productRankingItem.css.ts
@@ -1,0 +1,45 @@
+import { style } from '@vanilla-extract/css';
+
+export const productRankingItemContainer = style({
+  width: 144,
+});
+
+export const productRankingImageWrapper = style({
+  position: 'relative',
+  width: '100%',
+  height: 144,
+  border: '1px solid #E6E6E6',
+  borderRadius: 6,
+});
+
+export const productRankingImage = style({
+  width: '100%',
+  height: '100%',
+  borderRadius: 6,
+});
+
+export const productRankingRank = style({
+  position: 'absolute',
+  top: 10,
+  left: 10,
+  color: '#808080',
+  fontSize: 36,
+  fontFamily: 'Poppins, sans-serif',
+  fontStyle: 'italic',
+  fontWeight: '500',
+});
+
+export const productRankingTitle = style({
+  color: '#232527',
+  fontSize: 13,
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+});
+
+export const productRankingPrice = style({
+  color: '#808080',
+  fontSize: 12,
+  fontWeight: 600,
+});

--- a/src/components/Rank/ProductRankingList/ProductRankingList.stories.tsx
+++ b/src/components/Rank/ProductRankingList/ProductRankingList.stories.tsx
@@ -2,12 +2,23 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import ProductRankingList from './ProductRankingList';
 
+import mockProductRankingList from '@/mocks/data/productRankingList.json';
+
 const meta: Meta<typeof ProductRankingList> = {
   title: 'product/ProductRankingList',
   component: ProductRankingList,
+  args: {
+    product: mockProductRankingList,
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: () => (
+    <div style={{ width: '375px' }}>
+      <ProductRankingList />
+    </div>
+  ),
+};

--- a/src/components/Rank/ProductRankingList/ProductRankingList.tsx
+++ b/src/components/Rank/ProductRankingList/ProductRankingList.tsx
@@ -4,7 +4,7 @@ import { PATH } from '@/constants/path';
 import { useGA } from '@/hooks/common';
 import { useProductRankingQuery } from '@/hooks/queries/rank';
 import ProductRankingItem from '../ProductRankingItem/ProductRankingItem';
-import { productRankingListContainer } from './productRankingList.css';
+import { container } from './productRankingList.css';
 
 const ProductRankingList = () => {
   const { data: productRankings } = useProductRankingQuery();
@@ -15,7 +15,7 @@ const ProductRankingList = () => {
   };
 
   return (
-    <ul className={productRankingListContainer}>
+    <ul className={container}>
       {productRankings.products.map(({ id, name, image, price, categoryType }, index) => (
         <li key={id}>
           <Link to={`${PATH.PRODUCT_LIST}/${categoryType}/${id}`} onClick={handleProductRankingLinkClick}>

--- a/src/components/Rank/ProductRankingList/ProductRankingList.tsx
+++ b/src/components/Rank/ProductRankingList/ProductRankingList.tsx
@@ -1,37 +1,26 @@
-import { Link, Spacing } from '@fun-eat/design-system';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { ProductOverviewItem } from '@/components/Product';
 import { PATH } from '@/constants/path';
 import { useGA } from '@/hooks/common';
 import { useProductRankingQuery } from '@/hooks/queries/rank';
-import displaySlice from '@/utils/displaySlice';
+import ProductRankingItem from '../ProductRankingItem/ProductRankingItem';
+import { productRankingListContainer } from './productRankingList.css';
 
-interface ProductRankingListProps {
-  isHomePage?: boolean;
-}
-
-const ProductRankingList = ({ isHomePage = false }: ProductRankingListProps) => {
+const ProductRankingList = () => {
   const { data: productRankings } = useProductRankingQuery();
   const { gaEvent } = useGA();
-  const productsToDisplay = displaySlice(isHomePage, productRankings.products, 3);
 
   const handleProductRankingLinkClick = () => {
     gaEvent({ category: 'link', action: '상품 랭킹 링크 클릭', label: '랭킹' });
   };
 
   return (
-    <ul>
-      {productsToDisplay.map(({ id, name, image, categoryType }, index) => (
+    <ul className={productRankingListContainer}>
+      {productRankings.products.map(({ id, name, image, price, categoryType }, index) => (
         <li key={id}>
-          <Link
-            as={RouterLink}
-            to={`${PATH.PRODUCT_LIST}/${categoryType}/${id}`}
-            onClick={handleProductRankingLinkClick}
-          >
-            <ProductOverviewItem rank={index + 1} name={name} image={image} />
+          <Link to={`${PATH.PRODUCT_LIST}/${categoryType}/${id}`} onClick={handleProductRankingLinkClick}>
+            <ProductRankingItem rank={index + 1} name={name} image={image} price={price} />
           </Link>
-          <Spacing size={16} />
         </li>
       ))}
     </ul>

--- a/src/components/Rank/ProductRankingList/productRankingList.css.ts
+++ b/src/components/Rank/ProductRankingList/productRankingList.css.ts
@@ -1,12 +1,12 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
-export const productRankingListContainer = style({
+export const container = style({
   display: 'flex',
   overflowX: 'auto',
   overflowY: 'hidden',
   columnGap: '9px',
 });
 
-globalStyle(`${productRankingListContainer}::-webkit-scrollbar`, {
+globalStyle(`${container}::-webkit-scrollbar`, {
   display: 'none',
 });

--- a/src/components/Rank/ProductRankingList/productRankingList.css.ts
+++ b/src/components/Rank/ProductRankingList/productRankingList.css.ts
@@ -1,0 +1,12 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const productRankingListContainer = style({
+  display: 'flex',
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  columnGap: '9px',
+});
+
+globalStyle(`${productRankingListContainer}::-webkit-scrollbar`, {
+  display: 'none',
+});

--- a/src/components/Rank/index.ts
+++ b/src/components/Rank/index.ts
@@ -1,5 +1,6 @@
 export { default as ReviewRankingItem } from './ReviewRankingItem/ReviewRankingItem';
 export { default as ReviewRankingList } from './ReviewRankingList/ReviewRankingList';
+export { default as ProductRankingItem } from './ProductRankingItem/ProductRankingItem';
 export { default as ProductRankingList } from './ProductRankingList/ProductRankingList';
 export { default as RecipeRankingItem } from './RecipeRankingItem/RecipeRankingItem';
 export { default as RecipeRankingList } from './RecipeRankingList/RecipeRankingList';

--- a/src/mocks/data/productRankingList.json
+++ b/src/mocks/data/productRankingList.json
@@ -4,19 +4,22 @@
       "id": 3,
       "name": "구운감자슬림명란마요요요요요요요요요요요요용요요용요요ㅛ",
       "image": "https://t3.ftcdn.net/jpg/06/06/91/70/240_F_606917032_4ujrrMV8nspZDX8nTgGrTpJ69N9JNxOL.jpg",
-      "categoryType": "food"
+      "categoryType": "food",
+      "price": 1200
     },
     {
       "id": 2,
       "name": "삼립)보름달피치문",
       "image": "https://t3.ftcdn.net/jpg/06/06/91/70/240_F_606917032_4ujrrMV8nspZDX8nTgGrTpJ69N9JNxOL.jpg",
-      "categoryType": "store"
+      "categoryType": "store",
+      "price": 1200
     },
     {
       "id": 4,
       "name": "하얀짜파게티큰사발",
       "image": "https://t3.ftcdn.net/jpg/06/06/91/70/240_F_606917032_4ujrrMV8nspZDX8nTgGrTpJ69N9JNxOL.jpg",
-      "categoryType": "food"
+      "categoryType": "food",
+      "price": 1200
     }
   ]
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -74,7 +74,7 @@ export const HomePage = () => {
         </RankingInfoWrapper>
         <ErrorBoundary fallback={ErrorComponent} handleReset={reset}>
           <Suspense fallback={<Loading />}>
-            <ProductRankingList isHomePage />
+            <ProductRankingList />
           </Suspense>
         </ErrorBoundary>
       </SectionWrapper>

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -2,7 +2,7 @@ import type { CategoryVariant } from './common';
 import type { Member } from './member';
 import type { Product } from './product';
 
-export type ProductRanking = Pick<Product, 'id' | 'name' | 'image'> & { categoryType: string };
+export type ProductRanking = Pick<Product, 'id' | 'name' | 'image' | 'price'> & { categoryType: string };
 
 export interface ReviewRanking {
   reviewId: number;


### PR DESCRIPTION
## Issue

- close #26 

## ✨ 구현한 기능

- 상품 랭킹을 구현하였습니다.

기존에는 ProductOverviewItem이라는 컴포넌트를 통해서 상품 랭킹을 보여주고 있었는데,
다른 곳에서도 사용되고 있어 따로 ProductRankingItem 컴포넌트를 구현하였습니다.

<img width="210" alt="스크린샷 2024-03-10 오후 1 43 51" src="https://github.com/fun-eat/funeat-client/assets/80464961/352dff7d-1ac7-4e37-bd6e-e08a0fc67cf1">

<img width="433" alt="스크린샷 2024-03-10 오후 1 40 42" src="https://github.com/fun-eat/funeat-client/assets/80464961/65c840b1-c884-486d-9ac5-9dfa993e2c8b">

## 📢 논의하고 싶은 내용

여기도 image type이 string | null 인데 이제 어지간하면 상품 사진은 다 있을 것이라 생각합니다.
일단 type은 그대로 두었는데 추후 이야기해보고 수정하도록 하겠습니다.

디자인이 변경되었습니다.
자세한 내용은 26번 이슈를 참고바랍니다...
해울님이 디자인 변경해주셔서 그거 바탕으로 디자인하였습니다.

스크롤 webkit 쓰는거 쟤는 webkit 안에 display:none이 들어간 거라 어떻게 써야할 지 모르겠더라구요?
GPT의 도움을 받았는데 저렇게 쓰는거 맞나요...? 일단은 잘 됩니다!
```css
globalStyle(`${productRankingListContainer}::-webkit-scrollbar`, {
  display: 'none',
});
```

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 30분
