### PR TITLE
feat: Page Header 구현

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -218,6 +218,15 @@
       <symbol id="trashcan" viewBox="0 0 24 24">
         <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
       </symbol>
+      <symbol id="arrowLeft" viewBox="0 0 25 24">
+        <path
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.2"
+          d="M16.24 3.661l-8.086 8.25 8.085 8.25"
+        />
+      </symbol>
       <symbol id="arrowRight" viewBox="0 0 24 24">
         <path
           fill="currentColor"

--- a/src/components/Common/PageHeader/PageHeader.stories.tsx
+++ b/src/components/Common/PageHeader/PageHeader.stories.tsx
@@ -19,21 +19,21 @@ export const Default: Story = {
 export const BackButton: Story = {
   args: {
     title: '조합실',
-    isBackActive: true,
+    hasBackLink: true,
   },
 };
 
 export const SearchButton: Story = {
   args: {
     title: '조합실',
-    isSearchActive: true,
+    hasSearchLink: true,
   },
 };
 
 export const AllActive: Story = {
   args: {
     title: '조합실',
-    isBackActive: true,
-    isSearchActive: true,
+    hasBackLink: true,
+    hasSearchLink: true,
   },
 };

--- a/src/components/Common/PageHeader/PageHeader.stories.tsx
+++ b/src/components/Common/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PageHeader from './PageHeader';
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'common/PageHeader',
+  component: PageHeader,
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+export const Default: Story = {
+  args: {
+    title: '조합실',
+  },
+};
+
+export const BackButton: Story = {
+  args: {
+    title: '조합실',
+    isBackActive: true,
+  },
+};
+
+export const SearchButton: Story = {
+  args: {
+    title: '조합실',
+    isSearchActive: true,
+  },
+};
+
+export const AllActive: Story = {
+  args: {
+    title: '조합실',
+    isBackActive: true,
+    isSearchActive: true,
+  },
+};

--- a/src/components/Common/PageHeader/PageHeader.tsx
+++ b/src/components/Common/PageHeader/PageHeader.tsx
@@ -8,16 +8,16 @@ import { useRoutePage } from '@/hooks/common';
 
 interface PageHeaderProps {
   title: string;
-  isBackActive?: boolean;
-  isSearchActive?: boolean;
+  hasBackLink?: boolean;
+  hasSearchLink?: boolean;
 }
 
-const PageHeader = ({ title, isBackActive, isSearchActive }: PageHeaderProps) => {
+const PageHeader = ({ title, hasBackLink, hasSearchLink }: PageHeaderProps) => {
   const { routeBack } = useRoutePage();
 
   return (
     <header className={container}>
-      {isBackActive ? (
+      {hasBackLink ? (
         <button type="button" onClick={routeBack}>
           <SvgIcon variant="arrowLeft" stroke="#444444" width={24} height={24} />
         </button>
@@ -25,7 +25,7 @@ const PageHeader = ({ title, isBackActive, isSearchActive }: PageHeaderProps) =>
         <div style={{ width: 24, height: 24 }} aria-hidden />
       )}
       <h1 className={headerTitle}>{title}</h1>
-      {isSearchActive ? (
+      {hasSearchLink ? (
         <Link to={`${PATH.SEARCH}/integrated`}>
           <SvgIcon variant="search2" stroke="#232527" width={20} height={20} />
         </Link>

--- a/src/components/Common/PageHeader/PageHeader.tsx
+++ b/src/components/Common/PageHeader/PageHeader.tsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+
+import { container, headerTitle } from './pageHeader.css';
+
+import SvgIcon from '../Svg/SvgIcon';
+import { PATH } from '@/constants/path';
+import { useRoutePage } from '@/hooks/common';
+
+interface PageHeaderProps {
+  title: string;
+  isBackActive?: boolean;
+  isSearchActive?: boolean;
+}
+
+const PageHeader = ({ title, isBackActive, isSearchActive }: PageHeaderProps) => {
+  const { routeBack } = useRoutePage();
+
+  return (
+    <header className={container}>
+      {isBackActive ? (
+        <button type="button" onClick={routeBack}>
+          <SvgIcon variant="arrowLeft" stroke="#444444" width={24} height={24} />
+        </button>
+      ) : (
+        <div style={{ width: 24, height: 24 }} aria-hidden />
+      )}
+      <h1 className={headerTitle}>{title}</h1>
+      {isSearchActive ? (
+        <Link to={`${PATH.SEARCH}/integrated`}>
+          <SvgIcon variant="search2" stroke="#232527" width={20} height={20} />
+        </Link>
+      ) : (
+        <div style={{ width: 20, height: 20 }} aria-hidden />
+      )}
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/src/components/Common/PageHeader/PageHeader.tsx
+++ b/src/components/Common/PageHeader/PageHeader.tsx
@@ -4,7 +4,6 @@ import { container, headerTitle } from './pageHeader.css';
 
 import SvgIcon from '../Svg/SvgIcon';
 import { PATH } from '@/constants/path';
-import { useRoutePage } from '@/hooks/common';
 
 interface PageHeaderProps {
   title: string;
@@ -13,14 +12,12 @@ interface PageHeaderProps {
 }
 
 const PageHeader = ({ title, hasBackLink, hasSearchLink }: PageHeaderProps) => {
-  const { routeBack } = useRoutePage();
-
   return (
     <header className={container}>
       {hasBackLink ? (
-        <button type="button" onClick={routeBack}>
+        <Link to=".." relative="path">
           <SvgIcon variant="arrowLeft" stroke="#444444" width={24} height={24} />
-        </button>
+        </Link>
       ) : (
         <div style={{ width: 24, height: 24 }} aria-hidden />
       )}

--- a/src/components/Common/PageHeader/pageHeader.css.ts
+++ b/src/components/Common/PageHeader/pageHeader.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  width: '100%',
+  height: 50,
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const headerTitle = style({
+  color: '#232527',
+  fontSize: 18,
+  fontWeight: 600,
+});

--- a/src/components/Common/Svg/SvgIcon.tsx
+++ b/src/components/Common/Svg/SvgIcon.tsx
@@ -34,6 +34,7 @@ export const SVG_ICON_VARIANTS = [
   'plane',
   'info',
   'trashcan',
+  'arrowLeft',
   'arrowRight',
   'heartEmpty',
   'heartFilled',

--- a/src/components/Common/Svg/SvgSprite.tsx
+++ b/src/components/Common/Svg/SvgSprite.tsx
@@ -183,6 +183,15 @@ const SvgSprite = () => {
       <symbol id="trashcan" viewBox="0 0 24 24">
         <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
       </symbol>
+      <symbol id="arrowLeft" viewBox="0 0 25 24">
+        <path
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.2"
+          d="M16.24 3.661l-8.086 8.25 8.085 8.25"
+        />
+      </symbol>
       <symbol id="arrowRight" viewBox="0 0 24 24">
         <path
           fill="currentColor"


### PR DESCRIPTION
## Issue

- close #44 

## ✨ 구현한 기능
Page Header를 구현하였습니다.

<img width="785" alt="스크린샷 2024-03-14 오후 3 40 56" src="https://github.com/fun-eat/funeat-client/assets/80464961/4930fc63-285e-40bf-9fbe-e988288d4f30">

## 📢 논의하고 싶은 내용

props 이름 괜찮나요? visible로 할까 하다가 그냥 active로 했는데 더 좋은 이름 있으면 추천해주세요!

PageHeader를 사용할만한 곳을 보았을 때, 100% 홈으로 간다고 보장을 못하겠더라구요.
그래서 버튼으로 만들어 기존에 있던 뒤로가기 훅을 가져다 사용했습니다.
Search의 경우에는 디자인 봤을 때, 이제 하나의 검색창을 사용할 것 같더라구요?
그래서 어디서든 누르면 통합 검색 페이지로 이동하게 두었습니다.
만약에 기존처럼 레시피/상품별로 따로 검색 페이지가 뜨게 되는거면 말씀해주세요! 수정하겠슴당
아 암튼 그래서 Search는 Link로 했습니다. 
하나는 button 하나는 Link여서 약간 통일감이 깨지긴하는데, 접근성적인 측면으로는 이게 맞는 거 같기도 하고...?

그리고 이게 space between 주는거다보니까 props 값이 없으면 컴포넌트 위치가 바뀌더라구요.
그래서 임의로 없을 때 보이지 않는 div를 끼워넣었습니다.
이것도 더 좋은 아이디어 있으면 말씀해주세요!

얘가 페이지의 header 역할인 거 같아서 header 태그를 사용하고 h1으로 title을 감싸줬는데
이 부분도 어색하거나 이상하면 말씀해주세요!

## 🎸 기타

기존에 arrow라는 아이콘이 있는데, 굵기랑 모양이 달라서 새로 arrowLeft 추가했습니다.
추후 디자인 다 수정하고 arrow 아이콘 삭제하면 될 듯~~

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 30분
