### PR TITLE
fix: Text 컴포넌트가 p와 span 태그 둘 다 사용할 수 있게 수정

### DIFF
--- a/src/components/Common/Text/Text.tsx
+++ b/src/components/Common/Text/Text.tsx
@@ -8,12 +8,15 @@ const Text = <T extends TextElement = 'p'>({
   size = 'body',
   weight = 'regular',
   color = 'default',
+  as,
   ...props
 }: TextProps<T>) => {
+  const Component = as || 'p';
+
   return (
-    <p className={text({ color, size, weight })} {...props}>
+    <Component className={text({ color, size, weight })} {...props}>
       {children}
-    </p>
+    </Component>
   );
 };
 


### PR DESCRIPTION
## Issue

- close #69

## ✨ 구현한 기능

전에 해온이 리뷰 달아줬는데.. 진짜 없었네요.. ㅋㅋㅋㅋㅋㅋㅋ 왜 된다고 생각했지?!??1 아무튼 Text 컴포넌트가 p와 span 태그 둘 다 사용할 수 있게 수정했습니다 

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 : 10분
