### PR TITLE
fix: item image 규격 맞지 않는 부분 수정

### DIFF
--- a/src/components/Product/ProductItem/ProductItem.tsx
+++ b/src/components/Product/ProductItem/ProductItem.tsx
@@ -1,17 +1,10 @@
 import { Skeleton } from '@fun-eat/design-system';
 import { memo, useState } from 'react';
 
-import {
-  container,
-  preview,
-  previewWrapper,
-  productImage,
-  productName,
-  productPrice,
-  summaryWrapper,
-} from './productItem.css';
+import { container, previewWrapper, productImage, summaryWrapper } from './productItem.css';
 
-import { SvgIcon } from '@/components/Common';
+import { SvgIcon, Text } from '@/components/Common';
+import { ellipsis } from '@/styles/common.css';
 import { vars } from '@/styles/theme.css';
 import type { Product } from '@/types/product';
 
@@ -39,22 +32,27 @@ const ProductItem = ({ product }: ProductItemProps) => {
         </div>
       )}
       <div style={{ height: '8px' }} />
-      <p className={productName}>{name}</p>
+      <Text className={ellipsis} size="caption3" weight="semiBold" color="sub">
+        {name}
+      </Text>
       <div style={{ height: '2px' }} />
-      <p className={productPrice}>{price.toLocaleString('ko-KR')}원</p>
+      {/* 추후 bold로 변경 */}
+      <Text size="caption2" weight="semiBold" color="sub">
+        {price.toLocaleString('ko-KR')}원
+      </Text>
       <div style={{ height: '8px' }} />
       <div className={summaryWrapper}>
         <div className={previewWrapper}>
           <SvgIcon variant="star2" width={11} height={11} fill={vars.colors.gray2} />
-          <span className={preview} aria-label={`${averageRating}점`}>
+          <Text as="span" size="caption3" color="disabled" aria-label={`${averageRating}점`}>
             {averageRating.toFixed(1)}
-          </span>
+          </Text>
         </div>
         <div className={previewWrapper}>
           <SvgIcon variant="review2" width={11} height={11} />
-          <span className={preview} aria-label={`리뷰 ${reviewCount}개`}>
+          <Text as="span" size="caption3" color="disabled" aria-label={`리뷰 ${reviewCount}개`}>
             {reviewCount}
-          </span>
+          </Text>
         </div>
       </div>
     </div>

--- a/src/components/Product/ProductItem/productItem.css.ts
+++ b/src/components/Product/ProductItem/productItem.css.ts
@@ -12,19 +12,6 @@ export const productImage = style({
   aspectRatio: '1 / 1',
 });
 
-export const productName = style({
-  fontWeight: 600,
-  lineHeight: 1.4,
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-});
-
-export const productPrice = style({
-  fontWeight: 500,
-  lineHeight: 1.4,
-});
-
 export const summaryWrapper = style({
   display: 'flex',
   gap: 12,

--- a/src/components/Product/ProductList/productList.css.ts
+++ b/src/components/Product/ProductList/productList.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridTemplateColumns: 'minmax(0, 1fr) 1fr',
   gridAutoRows: 'auto',
   columnGap: 10,
   rowGap: 20,

--- a/src/components/Product/ProductPreviewList/ProductPreviewList.tsx
+++ b/src/components/Product/ProductPreviewList/ProductPreviewList.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import { container } from './productPreviewList.css';
+import { container, productItemWrapper } from './productPreviewList.css';
 import ProductItem from '../ProductItem/ProductItem';
 
 import { PATH } from '@/constants/path';
@@ -23,7 +23,7 @@ const ProductPreviewList = ({ categoryId }: ProductPreviewListProps) => {
   return (
     <ul className={container}>
       {productToDisplay.map((product) => (
-        <li key={product.id}>
+        <li key={product.id} className={productItemWrapper}>
           <Link to={`${PATH.PRODUCT_LIST}/detail/${product.id}`}>
             <ProductItem product={product} />
           </Link>

--- a/src/components/Product/ProductPreviewList/productPreviewList.css.ts
+++ b/src/components/Product/ProductPreviewList/productPreviewList.css.ts
@@ -6,3 +6,7 @@ export const container = style({
   padding: '0 20px',
   overflowX: 'auto',
 });
+
+export const productItemWrapper = style({
+  minWidth: 163,
+});

--- a/src/components/Rank/RecipeRankingList/recipeRankingList.css.ts
+++ b/src/components/Rank/RecipeRankingList/recipeRankingList.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridTemplateColumns: 'minmax(0, 1fr) 1fr',
   gridAutoRows: 'auto',
   columnGap: 10,
   rowGap: 20,

--- a/src/components/Rank/ReviewRankingItem/ReviewRankingItem.tsx
+++ b/src/components/Rank/ReviewRankingItem/ReviewRankingItem.tsx
@@ -4,6 +4,7 @@ import { reviewImage, tagList, tag, tagName, reviewContent } from './reviewRanki
 
 import { Text } from '@/components/Common';
 import { REVIEW_CARD_DEFAULT_IMAGE_URL } from '@/constants/image';
+import { ellipsis } from '@/styles/common.css';
 import type { ReviewRanking } from '@/types/ranking';
 import displaySlice from '@/utils/displaySlice';
 
@@ -23,7 +24,7 @@ const ReviewRankingItem = ({ productName, content, tags, image }: ReviewRankingI
     <div>
       <img src={image ?? REVIEW_CARD_DEFAULT_IMAGE_URL} className={reviewImage} alt={productName} />
       <div style={{ height: '8px' }} />
-      <Text color="sub" size="caption2" weight="semiBold">
+      <Text className={ellipsis} color="sub" size="caption2" weight="semiBold">
         {productName}
       </Text>
       <div style={{ height: '4px' }} />

--- a/src/components/Rank/ReviewRankingItem/reviewRankingItem.css.ts
+++ b/src/components/Rank/ReviewRankingItem/reviewRankingItem.css.ts
@@ -4,7 +4,6 @@ import { style } from '@vanilla-extract/css';
 export const reviewImage = style({
   width: '100%',
   height: 'auto',
-  minWidth: 164,
   borderRadius: '6px',
   objectFit: 'cover',
   aspectRatio: '164 / 90',

--- a/src/components/Rank/ReviewRankingList/ReviewRankingList.tsx
+++ b/src/components/Rank/ReviewRankingList/ReviewRankingList.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import { container } from './reviewRankingList.css';
+import { container, reviewItemWrapper } from './reviewRankingList.css';
 import ReviewRankingItem from '../ReviewRankingItem/ReviewRankingItem';
 
 import { PATH } from '@/constants/path';
@@ -20,7 +20,7 @@ const ReviewRankingList = () => {
   return (
     <ul className={container}>
       {reviews.map(({ reviewId, productName, content, tags, image }) => (
-        <li key={reviewId}>
+        <li key={reviewId} className={reviewItemWrapper}>
           <Link to={`${PATH.REVIEW}/${reviewId}`} onClick={handleReviewRankingLinkClick}>
             <ReviewRankingItem productName={productName} content={content} tags={tags} image={image} />
           </Link>

--- a/src/components/Rank/ReviewRankingList/reviewRankingList.css.ts
+++ b/src/components/Rank/ReviewRankingList/reviewRankingList.css.ts
@@ -5,3 +5,7 @@ export const container = style({
   gap: 10,
   padding: '0 20px',
 });
+
+export const reviewItemWrapper = style({
+  minWidth: 164,
+});

--- a/src/components/Recipe/RecipeItem/RecipeItem.tsx
+++ b/src/components/Recipe/RecipeItem/RecipeItem.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
-  ellipsis,
   favoriteButtonWrapper,
   imageWrapper,
   productButtonWrapper,
@@ -29,6 +28,7 @@ import {
 import { PATH } from '@/constants/path';
 import RecipeItemProvider from '@/contexts/RecipeItemContext';
 import { useRecipeItemValueContext } from '@/hooks/context';
+import { ellipsis } from '@/styles/common.css';
 import type { Recipe } from '@/types/recipe';
 import { getRelativeDate } from '@/utils/date';
 import displaySlice from '@/utils/displaySlice';

--- a/src/components/Recipe/RecipeItem/recipeItem.css.ts
+++ b/src/components/Recipe/RecipeItem/recipeItem.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css';
 
 export const imageWrapper = style({
   position: 'relative',
+  lineHeight: 0,
 });
 
 export const recipeImage = style({

--- a/src/components/Recipe/RecipeItem/recipeItem.css.ts
+++ b/src/components/Recipe/RecipeItem/recipeItem.css.ts
@@ -3,7 +3,6 @@ import { style } from '@vanilla-extract/css';
 
 export const imageWrapper = style({
   position: 'relative',
-  lineHeight: 0,
 });
 
 export const recipeImage = style({
@@ -63,10 +62,4 @@ export const recipeProductsCount = style({
   left: '50%',
   transform: 'translate( -50%, -50% )',
   color: vars.colors.white,
-});
-
-export const ellipsis = style({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
 });

--- a/src/components/Recipe/RecipeList/recipeList.css.ts
+++ b/src/components/Recipe/RecipeList/recipeList.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridTemplateColumns: 'minmax(0, 1fr) 1fr',
   gridAutoRows: 'auto',
   columnGap: 10,
   rowGap: 20,

--- a/src/mocks/data/products.json
+++ b/src/mocks/data/products.json
@@ -3,7 +3,7 @@
   "products": [
     {
       "id": 1,
-      "name": "꼬북칩",
+      "name": "꼬북칩 꼬북칩 꼬북칩 꼬북칩 꼬북칩 꼬북칩 꼬북칩 ",
       "price": 1500,
       "image": "https://arqachylpmku8348141.cdn.ntruss.com/app/product/mst_product/8801056232979_L.jpg",
       "averageRating": 4.5,

--- a/src/mocks/data/recipes.json
+++ b/src/mocks/data/recipes.json
@@ -19,7 +19,7 @@
       "createdAt": "2023-08-05T10:10:10",
       "favoriteCount": 154,
       "favorite": true,
-      "content": "곰탕과 짜장면을 같이 먹을 수 있어요!",
+      "content": "곰탕과 짜장면을 같이 먹을 수 있어요! 곰탕과 짜장면을 같이 먹을 수 있어요! 곰탕과 짜장면을 같이 먹을 수 있어요! 곰탕과 짜장면을 같이 먹을 수 있어요!",
       "products": [
         {
           "id": 1,
@@ -204,7 +204,7 @@
     {
       "id": 5,
       "image": null,
-      "title": "초특급불닭콘치즈",
+      "title": "초특급불닭콘치즈 초특급불닭콘치즈 초특급불닭콘치즈 초특급불닭콘치즈 초특급불닭콘치즈",
       "author": {
         "nickname": "5번 글",
         "profileImage": "https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/84a20dae-4770-4497-ae25-2dd552261aab"

--- a/src/mocks/data/reviewRankingList.json
+++ b/src/mocks/data/reviewRankingList.json
@@ -3,7 +3,7 @@
     {
       "reviewId": 1,
       "productId": 1,
-      "productName": "구운감자슬림명란마요",
+      "productName": "구운감자슬림명란마요 구운감자슬림명란마요 구운감자슬림명란마요 구운감자슬림명란마요",
       "content": "할머니가 먹을 거 같은 맛입니다. 1960년 전쟁 때 맛 보고 싶었는데 그때는 너무 가난해서 먹을 수 없었는데요 이것보다 긴 리뷰도 잘려 보인답니다",
       "image": null,
       "categoryType": "food",

--- a/src/styles/common.css.ts
+++ b/src/styles/common.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const ellipsis = style({
+  maxWidth: 163,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});

--- a/src/styles/common.css.ts
+++ b/src/styles/common.css.ts
@@ -1,7 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
 export const ellipsis = style({
-  maxWidth: 163,
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',


### PR DESCRIPTION
## Issue

- close #105 

## ✨ 구현한 기능

item image 규격이 맞지 않는 부분 임시 수정하였습니다.

## 📢 논의하고 싶은 내용

전체적으로 이미지 규격이 맞지 않은 부분들 있잖아요?
그게 이미지 크기를 화면에 맞게 유동적으로 가져오는 부분만 그렇게 오류가 나더라구요.

요거 사용했던 컴포넌트들...
```tsx
export const reviewImage = style({
  width: '100%',
  height: 'auto',
  minWidth: 164,
  borderRadius: '6px',
  objectFit: 'cover',
  aspectRatio: '164 / 90',
});
```
이게 name이나 content가 너무 길어지게 되면, 이미지도 그 길이만큼 늘어나고 전체 레이아웃이 깨져요.

이 모든게 말줄임표 속성 때문이라는 것!!
말줄임표 속성을 삭제하면 레이아웃이 안 틀어집니다...
whiteSpace: 'nowrap', 요 친구때문에 이미지도 같이 늘어나는 듯??

결국 얘가 고정 width가 없어서 그런거 같긴한데 정확히는 모르겠네요?
그래서 말줄임표 속성에 max width를 설정해줬어요.
그러니까 제대로 작동하는데...
근데 이제 문제는 productItem에서 발생하는데 이 컴포넌트가 두군데에서 사용되거든요?

<img width="518" alt="스크린샷 2024-04-21 오후 1 33 42" src="https://github.com/fun-eat/funeat-client/assets/80464961/2ee5822b-4ea2-4057-ac6f-d45028f2e84e">

<img width="419" alt="스크린샷 2024-04-21 오후 1 33 57" src="https://github.com/fun-eat/funeat-client/assets/80464961/1fb7c14d-492d-4282-8a16-6a2bd34f9fea">

첫번째 사진의 제목 공간이 다른 것보다 좁아서 얘 기준으로 잡으니까 
두번째 사진 제목처럼 컴포넌트 길이보다 좀 짧아요.

사진으로 티가 잘 안날 수 있는데 다른 컴포넌트로 보자면

<img width="215" alt="스크린샷 2024-04-21 오후 1 35 17" src="https://github.com/fun-eat/funeat-client/assets/80464961/b0742f8c-5407-4e7b-b9d7-6d1869b71267">

이렇게 이름이 이미지 길이보다 짧게 잘리는게 보이죠?
그래서 그냥 productItem이랑 recipeItem 이렇게 사용하는 곳에서 따로 길이 줄까 하다가
이것도 임시방편으로 만든 해결책이니까 어차피 덜어내야 할 거 같아서 그냥 뒀습니다...

더 좋은 방법이 생각난다면 댓글 달아주세요...!
저도 더 생각해보겠음!

## 🎸 기타

x
