### PR TITLE
feat: 상품 목록 배너 추가

### DIFF
--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -8,3 +8,6 @@ export const RECIPE_CARD_DEFAULT_IMAGE_URL_2 = `${IMAGE_BASE_URL}recipe-card-def
 export const RECIPE_CARD_DEFAULT_IMAGE_URL_3 = `${IMAGE_BASE_URL}recipe-card-default_3.png`;
 export const RECIPE_CARD_DEFAULT_IMAGE_URL_4 = `${IMAGE_BASE_URL}recipe-card-default_4.png`;
 export const RECIPE_CARD_DEFAULT_IMAGE_URL_5 = `${IMAGE_BASE_URL}recipe-card-default_5.png`;
+
+export const PRODUCT_BANNER = `${IMAGE_BASE_URL}product-banner.png`;
+export const STORE_BANNER = `${IMAGE_BASE_URL}store-banner.png`;

--- a/src/pages/ProductPage/ProductPage.tsx
+++ b/src/pages/ProductPage/ProductPage.tsx
@@ -20,6 +20,7 @@ import { useTabMenu } from '@/hooks/common';
 import { useCategoryQuery } from '@/hooks/queries/product';
 import { vars } from '@/styles/theme.css';
 import type { CategoryVariant, Tab } from '@/types/common';
+import { PRODUCT_BANNER, STORE_BANNER } from '@/constants/image';
 
 const TAB_MENUS: Tab<CategoryVariant>[] = [
   { value: CATEGORY_TYPE.FOOD, label: '공통 상품' },
@@ -39,6 +40,10 @@ export const ProductPage = () => {
     <>
       <TabMenu tabMenus={TAB_MENUS} selectedTabMenu={selectedTabMenu} handleTabMenuSelect={handleTabMenuClick} />
 
+      {selectedTabMenu === TAB_MENUS[1].value && (
+        <img src={STORE_BANNER} width={'100%'} height={180} alt="편의점 배너" />
+      )}
+
       <section className={categorySection}>
         <Suspense fallback={null}>
           {selectedTabMenu === TAB_MENUS[0].value ? (
@@ -49,7 +54,11 @@ export const ProductPage = () => {
         </Suspense>
       </section>
 
-      <div style={{ height: '12px', backgroundColor: vars.colors.border.light }} aria-hidden />
+      {selectedTabMenu === TAB_MENUS[0].value ? (
+        <img src={PRODUCT_BANNER} width={'100%'} height={72} alt="상품 배너" />
+      ) : (
+        <div style={{ height: '12px', backgroundColor: vars.colors.border.light }} aria-hidden />
+      )}
 
       <ErrorBoundary fallback={ErrorComponent} handleReset={reset}>
         <Suspense fallback={<Loading />}>


### PR DESCRIPTION
## Issue

- close #116 

## ✨ 구현한 기능

상품 목록 배너를 추가했습니다.

## 📢 논의하고 싶은 내용

x

## 🎸 기타

이미지의 규격이 375px인데 전체 페이지의 규격과 맞지 않아
이미지가 깨지는 모습을 볼 수 있습니다.
오늘 회의 때 디자이너분들께 말씀 드릴 예정!

## ⏰ 일정

- 추정 시간 : 30분
- 걸린 시간 : 10분
