### PR TITLE
fix: 조합실 리스트 grid 레이아웃 깨지는 오류 해결

### DIFF
--- a/src/components/Recipe/RecipeList/recipeList.css.ts
+++ b/src/components/Recipe/RecipeList/recipeList.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: 'minmax(0, 1fr) 1fr',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
   gridAutoRows: 'auto',
   columnGap: 10,
   rowGap: 20,


### PR DESCRIPTION
## Issue

- close #119

## ✨ 구현한 기능

https://github.com/fun-eat/funeat-client/assets/55427367/6f619452-218d-4b79-8b0f-42bfcf615211


로컬에선 됩니다 일단..

## 📢 논의하고 싶은 내용

-x


## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 : 10분
