### PR TITLE
refactor: 작성된 리뷰가 없는 경우 디자인 수정

### DIFF
--- a/src/components/Review/ReviewList/ReviewList.tsx
+++ b/src/components/Review/ReviewList/ReviewList.tsx
@@ -1,8 +1,9 @@
 import { useRef } from 'react';
 
-import { container } from './reviewList.css';
+import { container, notFound } from './reviewList.css';
 import ReviewItem from '../ReviewItem/ReviewItem';
 
+import SearchNotFoundImage from '@/assets/search-notfound.png';
 import { Loading, Text } from '@/components/Common';
 import { useIntersectionObserver } from '@/hooks/common';
 import { useInfiniteProductReviewsQuery } from '@/hooks/queries/product';
@@ -24,7 +25,14 @@ const ReviewList = ({ productId, selectedOption }: ReviewListProps) => {
   const reviews = data.pages.flatMap((page) => page.reviews);
 
   if (reviews.length === 0) {
-    return <Text>상품의 첫 리뷰를 작성해주세요</Text>;
+    return (
+      <div className={notFound}>
+        <img src={SearchNotFoundImage} width={335} alt="검색 결과 없음" />
+        <Text color="disabled" size="caption4">
+          아직 작성된 리뷰가 없어요
+        </Text>
+      </div>
+    );
   }
 
   return (

--- a/src/components/Review/ReviewList/ReviewList.tsx
+++ b/src/components/Review/ReviewList/ReviewList.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { container, notFound } from './reviewList.css';
 import ReviewItem from '../ReviewItem/ReviewItem';
 
-import SearchNotFoundImage from '@/assets/search-notfound.png';
+import ReviewNotFoundImage from '@/assets/review-notfound.png';
 import { Loading, Text } from '@/components/Common';
 import { useIntersectionObserver } from '@/hooks/common';
 import { useInfiniteProductReviewsQuery } from '@/hooks/queries/product';
@@ -27,10 +27,13 @@ const ReviewList = ({ productId, selectedOption }: ReviewListProps) => {
   if (reviews.length === 0) {
     return (
       <div className={notFound}>
-        <img src={SearchNotFoundImage} width={335} alt="검색 결과 없음" />
+        <div style={{ height: 52 }} />
+        <img src={ReviewNotFoundImage} width={117} alt="검색 결과 없음" />
+        <div style={{ height: 25 }} />
         <Text color="disabled" size="caption4">
-          아직 작성된 리뷰가 없어요
+          새로운 리뷰를 작성해주세요
         </Text>
+        <div style={{ height: 20 }} />
       </div>
     );
   }

--- a/src/components/Review/ReviewList/reviewList.css.ts
+++ b/src/components/Review/ReviewList/reviewList.css.ts
@@ -6,3 +6,11 @@ export const container = style({
   rowGap: 40,
   padding: '0 20px',
 });
+
+export const notFound = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 6,
+  textAlign: 'center',
+});

--- a/src/pages/ProductDetailPage/productDetailPage.css.ts
+++ b/src/pages/ProductDetailPage/productDetailPage.css.ts
@@ -27,7 +27,7 @@ export const linkWrapper = style({
   height: 70,
   maxWidth: 440,
   padding: '0 20px',
-  border: `1px solid ${vars.colors.border.default}`,
+  borderTop: `1px solid ${vars.colors.border.default}`,
   backgroundColor: vars.colors.background.default,
   transform: 'translateX(-50%)',
 });


### PR DESCRIPTION
## Issue

- close #130 

## ✨ 구현한 기능

'작성된 리뷰가 없는 경우' 디자인이 되어 있지 않아 수정하였습니다.
QA 엑셀에 적어놨는데, 완료로 체크해놓겠습니다!
피그마에 따로 없어서, 상위에 있는 꿀조합이랑 동일한 디자인으로 수정하였습니다.
또, 리뷰 작성하기 버튼을 둘러싸고 있는 border를 top만 적용되게 수정하였습니다.

<img width="477" alt="스크린샷 2024-05-19 오후 1 28 16" src="https://github.com/fun-eat/funeat-client/assets/80464961/049be25b-5a48-48f9-bf88-1da92a44402a">

### +) 수정
리뷰 없는 버전 디자인 나와서 수정하였습니다!

<img width="454" alt="스크린샷 2024-05-22 오후 4 57 44" src="https://github.com/fun-eat/funeat-client/assets/80464961/6b5c5c79-7701-4076-b141-44c38e13fe66">


## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 10분
- 걸린 시간 : 5분
