### PR TITLE
fix: 태그 검색의 endpoint를 tagId로 변경

### DIFF
--- a/src/components/Search/TagSearchResultList/TagSearchResultList.tsx
+++ b/src/components/Search/TagSearchResultList/TagSearchResultList.tsx
@@ -10,15 +10,11 @@ import { useIntersectionObserver } from '@/hooks/common';
 import { useInfiniteProductSearchResultsQuery } from '@/hooks/queries/search';
 
 interface TagSearchResultListProps {
-  searchQuery: string;
+  tagId: string;
 }
 
-const TagSearchResultList = ({ searchQuery }: TagSearchResultListProps) => {
-  const {
-    data: searchResponse,
-    fetchNextPage,
-    hasNextPage,
-  } = useInfiniteProductSearchResultsQuery(searchQuery, 'tags');
+const TagSearchResultList = ({ tagId }: TagSearchResultListProps) => {
+  const { data: searchResponse, fetchNextPage, hasNextPage } = useInfiniteProductSearchResultsQuery(tagId, 'tags');
 
   const scrollRef = useRef<HTMLDivElement>(null);
   useIntersectionObserver<HTMLDivElement>(fetchNextPage, scrollRef, hasNextPage);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -81,7 +81,7 @@ export const PAGE_TITLE = {
 
 export const RECOMMENDED_TAGS = [
   { id: 1, name: '맛있어요', tagType: 'TASTE' },
-  { id: 2, name: '간식', tagType: 'ETC' },
-  { id: 3, name: '갓성비', tagType: 'QUANTITY' },
-  { id: 4, name: '달달해요', tagType: 'TASTE' },
+  { id: 15, name: '간식', tagType: 'ETC' },
+  { id: 11, name: '갓성비', tagType: 'QUANTITY' },
+  { id: 5, name: '달달해요', tagType: 'TASTE' },
 ];

--- a/src/hooks/queries/search/useInfiniteProductSearchResultsQuery.ts
+++ b/src/hooks/queries/search/useInfiniteProductSearchResultsQuery.ts
@@ -8,7 +8,7 @@ type SearchResultEndPoint = 'tags' | 'products';
 const fetchProductSearchResults = async (query: string, endpoint: SearchResultEndPoint, pageParam: number) => {
   const response = await searchApi.get({
     params: `/${endpoint}/results`,
-    queries: `?query=${query}&lastProductId=${pageParam}`,
+    queries: `?${endpoint === 'tags' ? 'tagId' : 'query'}=${query}&lastProductId=${pageParam}`,
   });
   const data: ProductSearchResultResponse = await response.json();
 

--- a/src/hooks/search/useSearch.ts
+++ b/src/hooks/search/useSearch.ts
@@ -79,12 +79,11 @@ const useSearch = () => {
     setIsAutocompleteOpen(false);
   };
 
-  const handleTagSearch: MouseEventHandler<HTMLButtonElement> = (event) => {
-    const { value } = event.currentTarget;
-    setSearchQuery(value);
+  const handleTagSearch = (id: number, name: string) => {
+    setSearchQuery(name);
     setIsSubmitted(true);
 
-    navigate(`${PATH.SEARCH}/tags?query=${value}`);
+    navigate(`${PATH.SEARCH}/tags?query=${name}&id=${id}`);
   };
 
   const resetSearchQuery = () => {

--- a/src/mocks/handlers/searchHandlers.ts
+++ b/src/mocks/handlers/searchHandlers.ts
@@ -7,19 +7,27 @@ import searchingProducts from '../data/searchingProducts.json';
 export const searchHandlers = [
   rest.get('/api/search/:searchId/results', (req, res, ctx) => {
     const { searchId } = req.params;
-    const query = req.url.searchParams.get('query');
+    const query = req.url.searchParams.get('query') || req.url.searchParams.get('tagId');
     const page = Number(req.url.searchParams.get('page'));
 
     if (query === null) {
       return res(ctx.status(400));
     }
 
-    if (searchId === 'products' || searchId === 'tags') {
+    if (searchId === 'products') {
       const filteredProducts = {
         page: { ...productSearchResults.page },
         products: productSearchResults.products
           .filter((product) => product.name.includes(query))
           .slice(page * 5, (page + 1) * 5),
+      };
+      return res(ctx.status(200), ctx.json(filteredProducts), ctx.delay(1000));
+    }
+
+    if (searchId === 'tags') {
+      const filteredProducts = {
+        page: { ...productSearchResults.page },
+        products: productSearchResults.products.slice(page * 5, (page + 1) * 5),
       };
       return res(ctx.status(200), ctx.json(filteredProducts), ctx.delay(1000));
     }

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -121,7 +121,7 @@ export const SearchPage = () => {
               </Text>
               <div className={badgeContainer}>
                 {RECOMMENDED_TAGS.map(({ id, name }) => (
-                  <button type="button" key={id} value={name} onClick={handleTagSearch}>
+                  <button type="button" key={id} value={name} onClick={() => handleTagSearch(id, name)}>
                     <Badge color="#e6e6e6" textColor="#808080">
                       {name}
                     </Badge>

--- a/src/pages/SearchPage/TagSearchResultPage.tsx
+++ b/src/pages/SearchPage/TagSearchResultPage.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { form, formWrapper, searchResultTitle, searchSection } from './searchPage.css';
 
@@ -8,6 +9,9 @@ import { useSearch } from '@/hooks/search';
 
 export const TagSearchResultPage = () => {
   const { inputRef, searchQuery, isSubmitted, handleSearchQuery, handleSearchForm } = useSearch();
+
+  const [searchParams, _setSearchParams] = useSearchParams();
+  const tagId = searchParams.get('id') || '';
 
   return (
     <>
@@ -28,7 +32,7 @@ export const TagSearchResultPage = () => {
         </Text>
         <ErrorBoundary fallback={ErrorComponent}>
           <Suspense fallback={<Loading />}>
-            <TagSearchResultList searchQuery={searchQuery} />
+            <TagSearchResultList tagId={tagId} />
           </Suspense>
         </ErrorBoundary>
       </section>


### PR DESCRIPTION
## Issue

- close #136

## ✨ 구현한 기능

- 태그 검색의 endpoint를 tagId로 변경

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 30분
- 걸린 시간 : 30분
