### PR TITLE
refactor: any 제거

### DIFF
--- a/src/components/Common/TabMenu/TabMenu.tsx
+++ b/src/components/Common/TabMenu/TabMenu.tsx
@@ -3,12 +3,12 @@ import { forwardRef } from 'react';
 
 import { container, menuName, tabMenu } from './tabMenu.css';
 
-import type { Tab } from '@/types/common';
+import type { Tab, TabVariant } from '@/types/common';
 
 interface TabMenuProps {
-  tabMenus: Tab[];
-  selectedTabMenu: string;
-  handleTabMenuSelect: (selectedMenu: any) => void;
+  tabMenus: Tab<TabVariant>[];
+  selectedTabMenu: TabVariant;
+  handleTabMenuSelect: (selectedMenu: TabVariant) => void;
 }
 
 const TabMenu = (
@@ -16,7 +16,7 @@ const TabMenu = (
   ref: ForwardedRef<HTMLUListElement>
 ) => {
   const handleTabMenuClick: MouseEventHandler<HTMLButtonElement> = (event) => {
-    handleTabMenuSelect(event.currentTarget.value);
+    handleTabMenuSelect(event.currentTarget.value as TabVariant);
   };
 
   return (

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -12,6 +12,7 @@ import type { PATH } from '@/constants/path';
 
 export type CategoryVariant = 'food' | 'store';
 export type MemberPostVariant = 'recipe' | 'review';
+export type TabVariant = CategoryVariant | MemberPostVariant;
 
 export type Food = (typeof CATEGORY_TYPE)['FOOD'];
 export type Store = (typeof CATEGORY_TYPE)['STORE'];


### PR DESCRIPTION
## Issue

- close #154 

## ✨ 구현한 기능

TabMenu의 any를 제거했습니다.
대신 as 생김 ㅎ

## 📢 논의하고 싶은 내용

Tab을 사용하는 곳이 늘어나면, 그만큼 common.ts의 TabVariant에 추가해야함 (= 범용성 떨어짐)
하지만 any를 없애는 것에 의의를 두었음.
더 좋은 해결 방법을 알면 알려주세요.

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 10분
- 걸린 시간 : 10분
