### PR TITLE
fix: meta og image 버전 명시

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <meta property="og:description" content="궁금해? 맛있을걸? 먹어봐 🥄" />
     <meta property="og:url" content="https://funeat.site" />
     <meta property="og:site_name" content="펀잇" />
-    <meta property="og:image" content="/assets/og-image.png" />
+    <meta property="og:image" content="/assets/og-image.png?v=1" />
     <meta property="og:image:alt" content="펀잇" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko" />


### PR DESCRIPTION
## Issue

- close #156 

## ✨ 구현한 기능

바뀐 meta og image가 카카오톡에서는 적용되지 않고 있습니다.
이게 카카오톡은 따로 캐시를 초기화 해야 한다고 해서
[kakao developers](https://developers.kakao.com/tool/debugger/sharing)
여기서 날려줬거든여?

그래도 그대로여서 찾아봤는데
만약에 이미지만 갈아끼운 상태면 (파일명 변경 없이) 뒤에 버전을 명시해줘야
얘가 스크랩핑 할 때 바뀐 걸 알아차린다고 하네용
이거 머지하고 다시 캐시 날려보겠슴니다

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 1분
- 걸린 시간 : 1분
